### PR TITLE
fix(encode): never hand a backend a tune/preset it rejects (NVENC/QSV EINVAL)

### DIFF
--- a/src/config/validation.rs
+++ b/src/config/validation.rs
@@ -4214,15 +4214,30 @@ fn validate_video_encode(
             );
         }
     }
+    // `tune` vocabulary is per-backend: x264 / x265 share one table, NVENC has
+    // its own, and QSV / VAAPI expose no `tune` option at all.
+    //
+    // Validation stays permissive over the union, because `*_auto` resolves its
+    // backend per-host at flow start — a tune legal for the x264 this host picks
+    // may be illegal for the NVENC another host picks, and neither is knowable
+    // here. `video_encode_util::sanitise_tune` drops an incompatible tune (with
+    // a warning) once the backend is known, so no config can reach
+    // `avcodec_open2` with a tune that backend would reject.
     if let Some(ref t) = enc.tune {
         match t.as_str() {
             // Empty string = unset (encoder default).
-            "" | "zerolatency" | "film" | "animation" | "grain" | "stillimage"
-            | "fastdecode" | "psnr" | "ssim" => {}
+            "" => {}
+            // libx264 / libx265.
+            "zerolatency" | "film" | "animation" | "grain" | "stillimage" | "fastdecode"
+            | "psnr" | "ssim" => {}
+            // NVENC. Previously unrepresentable: an NVENC operator could not
+            // name a tune their encoder actually understands.
+            "hq" | "ll" | "ull" | "lossless" => {}
             other => bail!(
                 "{context}: video_encode.tune '{other}' is not recognised; \
                  expected one of (empty), zerolatency, film, animation, grain, \
-                 stillimage, fastdecode, psnr, ssim"
+                 stillimage, fastdecode, psnr, ssim (libx264/libx265), \
+                 or hq, ll, ull, lossless (NVENC)"
             ),
         }
     }

--- a/src/engine/video_encode_util.rs
+++ b/src/engine/video_encode_util.rs
@@ -88,6 +88,77 @@ fn backend_label(c: VideoEncoderCodec) -> &'static str {
     }
 }
 
+/// libx264 / libx265 tune vocabulary.
+const SW_TUNES: &[&str] = &[
+    "zerolatency",
+    "film",
+    "animation",
+    "grain",
+    "stillimage",
+    "fastdecode",
+    "psnr",
+    "ssim",
+];
+/// NVENC tune vocabulary. Disjoint from [`SW_TUNES`].
+const NVENC_TUNES: &[&str] = &["hq", "ll", "ull", "lossless"];
+
+/// Default `tune` when the operator did not set one.
+///
+/// `zerolatency` is an **x264/x265-only** tune. NVENC exposes a `tune` option
+/// too, but its vocabulary is `hq` / `ll` / `ull` / `lossless`; handing it
+/// `zerolatency` makes `avcodec_open2` fail with `EINVAL (-22)`. Defaulting it
+/// unconditionally therefore broke *every* NVENC user who did not explicitly
+/// set `tune: ""`.
+///
+/// Empty means "don't pass `tune` to the encoder at all" (see
+/// `video_engine::VideoEncoder::open`), which is the right default for the
+/// hardware backends: they are already low-latency by construction.
+fn default_tune_for(backend: VideoEncoderCodec) -> String {
+    match backend {
+        VideoEncoderCodec::X264 | VideoEncoderCodec::X265 => "zerolatency".to_string(),
+        _ => String::new(),
+    }
+}
+
+/// Drop a `tune` the resolved backend cannot accept, rather than letting
+/// `avcodec_open2` fail with an opaque `EINVAL (-22)`.
+///
+/// Config validation is permissive over the union of the vocabularies because
+/// `h264_auto` / `hevc_auto` resolve their backend per-host at flow start: a
+/// tune legal for the x264 one host picks is illegal for the NVENC another host
+/// picks, and neither is knowable at config load. This is the point where the
+/// backend *is* known, so it is the only place the check can be correct.
+///
+/// QSV and VAAPI expose no `tune` option at all — libavcodec ignores unknown
+/// dictionary entries, so passing one is harmless, but dropping it keeps the
+/// encoder's option dictionary honest.
+fn sanitise_tune(backend: VideoEncoderCodec, tune: String) -> String {
+    if tune.is_empty() {
+        return tune;
+    }
+    let acceptable: &[&str] = match backend {
+        VideoEncoderCodec::X264 | VideoEncoderCodec::X265 => SW_TUNES,
+        VideoEncoderCodec::H264Nvenc | VideoEncoderCodec::HevcNvenc => NVENC_TUNES,
+        // QSV / VAAPI: no `tune` option exists.
+        _ => &[],
+    };
+    if acceptable.contains(&tune.as_str()) {
+        return tune;
+    }
+    let accepts = if acceptable.is_empty() {
+        "no tune option".to_string()
+    } else {
+        acceptable.join(", ")
+    };
+    tracing::warn!(
+        error_code = "encoder_tune_not_supported",
+        "video_encode.tune '{tune}' is not supported by the {} backend ({accepts}); \
+         ignoring it — the encoder would otherwise fail to open with EINVAL",
+        backend_label(backend),
+    );
+    String::new()
+}
+
 /// Build a [`VideoEncoderConfig`] from the edge-side [`VideoEncodeConfig`],
 /// runtime-derived source dimensions, and the backend selected by the
 /// caller. `global_header` depends on the container — RTMP needs
@@ -133,7 +204,10 @@ pub fn build_encoder_config(
         crf: cfg.crf.unwrap_or(23),
         max_b_frames: cfg.bframes.unwrap_or(0),
         refs: cfg.refs.unwrap_or(0),
-        tune: cfg.tune.clone().unwrap_or_else(|| "zerolatency".to_string()),
+        tune: sanitise_tune(
+            backend,
+            cfg.tune.clone().unwrap_or_else(|| default_tune_for(backend)),
+        ),
         level: cfg.level.clone().unwrap_or_default(),
         color_primaries: cfg.color_primaries.clone().unwrap_or_default(),
         color_transfer: cfg.color_transfer.clone().unwrap_or_default(),
@@ -705,4 +779,95 @@ fn is_planar_yuv_av_pix_fmt(av_pix_fmt: i32) -> bool {
     // thin shim — the constants live in `libffmpeg-video-sys` which
     // bilbycast-edge does not depend on directly.
     video_engine::is_planar_yuv_av_pix_fmt(av_pix_fmt)
+}
+
+#[cfg(test)]
+mod tune_tests {
+    use super::{default_tune_for, sanitise_tune};
+    use video_codec::VideoEncoderCodec::{self, *};
+
+    const ALL_BACKENDS: &[VideoEncoderCodec] = &[
+        X264, X265, H264Nvenc, HevcNvenc, H264Qsv, HevcQsv, H264Vaapi, HevcVaapi,
+    ];
+
+    /// `zerolatency` is x264-only. Defaulting it for every backend made
+    /// `avcodec_open2` return EINVAL(-22) for every NVENC user who did not
+    /// explicitly set `tune: ""` — i.e. all of them.
+    #[test]
+    fn zerolatency_defaults_only_for_software_backends() {
+        assert_eq!(default_tune_for(X264), "zerolatency");
+        assert_eq!(default_tune_for(X265), "zerolatency");
+        for &b in &[H264Nvenc, HevcNvenc, H264Qsv, HevcQsv, H264Vaapi, HevcVaapi] {
+            assert_eq!(
+                default_tune_for(b),
+                "",
+                "{b:?} must not default to an x264 tune",
+            );
+        }
+    }
+
+    /// The invariant that actually protects the encoder: whatever the operator
+    /// (or the `*_auto` resolver) produces, the tune handed to `avcodec_open2`
+    /// is one that backend accepts — or empty, meaning "not passed at all".
+    #[test]
+    fn no_backend_ever_receives_a_tune_it_rejects() {
+        let every_tune = [
+            "zerolatency",
+            "film",
+            "animation",
+            "grain",
+            "stillimage",
+            "fastdecode",
+            "psnr",
+            "ssim",
+            "hq",
+            "ll",
+            "ull",
+            "lossless",
+            "",
+        ];
+        for &backend in ALL_BACKENDS {
+            let acceptable: &[&str] = match backend {
+                X264 | X265 => super::SW_TUNES,
+                H264Nvenc | HevcNvenc => super::NVENC_TUNES,
+                _ => &[],
+            };
+            for tune in every_tune {
+                let out = sanitise_tune(backend, tune.to_string());
+                assert!(
+                    out.is_empty() || acceptable.contains(&out.as_str()),
+                    "{backend:?} would receive unsupported tune {out:?}",
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn valid_tunes_survive_sanitisation() {
+        assert_eq!(sanitise_tune(X264, "zerolatency".into()), "zerolatency");
+        assert_eq!(sanitise_tune(X265, "grain".into()), "grain");
+        assert_eq!(sanitise_tune(H264Nvenc, "ll".into()), "ll");
+        assert_eq!(sanitise_tune(HevcNvenc, "hq".into()), "hq");
+    }
+
+    #[test]
+    fn cross_family_tunes_are_dropped_not_passed_through() {
+        // The reported bug, exactly.
+        assert_eq!(sanitise_tune(H264Nvenc, "zerolatency".into()), "");
+        // And its mirror image.
+        assert_eq!(sanitise_tune(X264, "ll".into()), "");
+        // QSV / VAAPI have no tune option at all.
+        assert_eq!(sanitise_tune(H264Qsv, "zerolatency".into()), "");
+        assert_eq!(sanitise_tune(HevcVaapi, "hq".into()), "");
+    }
+
+    /// The SW and NVENC vocabularies must stay disjoint, otherwise
+    /// `sanitise_tune`'s per-family dispatch would silently accept a tune for
+    /// the wrong backend.
+    #[test]
+    fn tune_vocabularies_are_disjoint() {
+        for t in super::NVENC_TUNES {
+            assert!(!super::SW_TUNES.contains(t), "{t} appears in both tables");
+        }
+    }
 }

--- a/src/engine/video_encode_util.rs
+++ b/src/engine/video_encode_util.rs
@@ -159,6 +159,52 @@ fn sanitise_tune(backend: VideoEncoderCodec, tune: String) -> String {
     String::new()
 }
 
+/// Map a preset the resolved backend cannot accept onto its nearest
+/// equivalent, rather than letting `avcodec_open2` fail with `EINVAL (-22)`.
+///
+/// `tune`'s sibling, with one difference: an unsupported tune is safely
+/// *dropped* (the encoder picks its default), but a preset carries the
+/// operator's speed/quality intent, so it is *mapped* — an `ultrafast` ask on
+/// NVENC becomes `fast`, not silence.
+///
+/// Vocabularies, per the vendored FFmpeg n7.1.3:
+/// * libx264 / libx265 accept the full nine-name ladder.
+/// * NVENC's named presets are `slow` / `medium` / `fast` (plus `p1`–`p7` and
+///   legacy names the edge never emits). `ultrafast` et al. ⇒ EINVAL at open.
+/// * QSV accepts `veryfast` … `veryslow` — everything except `ultrafast` /
+///   `superfast`.
+/// * VAAPI exposes no `preset` option; libavcodec ignores the unknown dict
+///   entry, so anything is safe there.
+///
+/// Lives post-resolution for the same reason as [`sanitise_tune`]: with
+/// `h264_auto` / `hevc_auto` the backend — and hence the legal vocabulary —
+/// is only known here.
+fn sanitise_preset(backend: VideoEncoderCodec, preset: VideoPreset) -> VideoPreset {
+    use VideoPreset::*;
+    let mapped = match backend {
+        VideoEncoderCodec::H264Nvenc | VideoEncoderCodec::HevcNvenc => match preset {
+            Ultrafast | Superfast | Veryfast | Faster => Fast,
+            Slower | Veryslow => Slow,
+            ok => return ok,
+        },
+        VideoEncoderCodec::H264Qsv | VideoEncoderCodec::HevcQsv => match preset {
+            Ultrafast | Superfast => Veryfast,
+            ok => return ok,
+        },
+        // x264 / x265 accept the full ladder; VAAPI ignores the option.
+        _ => return preset,
+    };
+    tracing::warn!(
+        error_code = "encoder_preset_not_supported",
+        "video_encode.preset '{}' is not supported by the {} backend; \
+         using '{}' instead — the encoder would otherwise fail to open with EINVAL",
+        preset.as_str(),
+        backend_label(backend),
+        mapped.as_str(),
+    );
+    mapped
+}
+
 /// Build a [`VideoEncoderConfig`] from the edge-side [`VideoEncodeConfig`],
 /// runtime-derived source dimensions, and the backend selected by the
 /// caller. `global_header` depends on the container — RTMP needs
@@ -196,7 +242,7 @@ pub fn build_encoder_config(
         bitrate_kbps,
         max_bitrate_kbps: cfg.max_bitrate_kbps.unwrap_or(0),
         gop_size,
-        preset: resolve_preset(cfg.preset.as_deref()),
+        preset: sanitise_preset(backend, resolve_preset(cfg.preset.as_deref())),
         profile: resolve_profile(cfg.profile.as_deref()),
         chroma: resolve_chroma(cfg.chroma.as_deref()),
         bit_depth: cfg.bit_depth.unwrap_or(8),
@@ -868,6 +914,69 @@ mod tune_tests {
     fn tune_vocabularies_are_disjoint() {
         for t in super::NVENC_TUNES {
             assert!(!super::SW_TUNES.contains(t), "{t} appears in both tables");
+        }
+    }
+}
+
+#[cfg(test)]
+mod preset_tests {
+    use super::sanitise_preset;
+    use video_codec::VideoEncoderCodec::{self, *};
+    use video_codec::VideoPreset::{self, *};
+
+    const ALL_PRESETS: &[VideoPreset] = &[
+        Ultrafast, Superfast, Veryfast, Faster, Fast, Medium, Slow, Slower, Veryslow,
+    ];
+
+    /// The invariant: whatever the operator (or the `*_auto` resolver)
+    /// produces, the preset handed to `avcodec_open2` is one that backend
+    /// accepts. NVENC's named presets are slow/medium/fast; QSV rejects
+    /// ultrafast/superfast. Handing either an x264-only name is EINVAL.
+    #[test]
+    fn no_backend_ever_receives_a_preset_it_rejects() {
+        for &p in ALL_PRESETS {
+            for &b in &[H264Nvenc, HevcNvenc] {
+                assert!(
+                    matches!(sanitise_preset(b, p), Fast | Medium | Slow),
+                    "{b:?} would receive unsupported preset {:?}",
+                    sanitise_preset(b, p),
+                );
+            }
+            for &b in &[H264Qsv, HevcQsv] {
+                assert!(
+                    !matches!(sanitise_preset(b, p), Ultrafast | Superfast),
+                    "{b:?} would receive unsupported preset {:?}",
+                    sanitise_preset(b, p),
+                );
+            }
+        }
+    }
+
+    /// Mapping preserves the operator's speed/quality intent rather than
+    /// silently resetting to a default: fast asks stay fast, slow stay slow.
+    #[test]
+    fn mapping_preserves_speed_intent() {
+        // The reported bug, exactly: ultrafast on NVENC.
+        assert_eq!(sanitise_preset(H264Nvenc, Ultrafast), Fast);
+        assert_eq!(sanitise_preset(HevcNvenc, Veryslow), Slow);
+        assert_eq!(sanitise_preset(H264Qsv, Ultrafast), Veryfast);
+    }
+
+    /// Presets the backend accepts pass through untouched — including on
+    /// x264/x265 (full ladder) and VAAPI (no preset option; harmless).
+    #[test]
+    fn supported_presets_pass_through() {
+        for &p in ALL_PRESETS {
+            assert_eq!(sanitise_preset(X264, p), p);
+            assert_eq!(sanitise_preset(X265, p), p);
+            assert_eq!(sanitise_preset(H264Vaapi, p), p);
+            assert_eq!(sanitise_preset(HevcVaapi, p), p);
+        }
+        for &p in &[Fast, Medium, Slow] {
+            assert_eq!(sanitise_preset(H264Nvenc, p), p);
+        }
+        for &p in &[Veryfast, Faster, Fast, Medium, Slow, Slower, Veryslow] {
+            assert_eq!(sanitise_preset(H264Qsv, p), p);
         }
     }
 }


### PR DESCRIPTION
`build_encoder_config` defaulted `tune` to `"zerolatency"` whenever unset — an **x264/x265-only** tune. NVENC's `tune` vocabulary is `hq`/`ll`/`ull`/`lossless`, so libavcodec rejects `zerolatency` and `avcodec_open2` fails with `EINVAL (-22)`: **every NVENC output failed to open** unless the operator happened to set `tune: ""`. Nothing suggested they should, and the error surfaced only as an opaque `-22`.

- `default_tune_for(backend)` — only libx264/libx265 default to `zerolatency`; hardware backends default to empty (low-latency by construction).
- `sanitise_tune(backend, tune)` — drop a tune the *resolved* backend cannot accept, with an `encoder_tune_not_supported` warning, rather than letting it reach `avcodec_open2`.
- `sanitise_preset(backend, preset)` — the sibling case. NVENC's named presets are only `slow`/`medium`/`fast`, QSV lacks `ultrafast`/`superfast`. Unlike a tune (safely dropped), a preset carries speed/quality *intent*, so it is **mapped** to the nearest supported name (`ultrafast…faster → fast` on NVENC, `slower/veryslow → slow`; etc.), with an `encoder_preset_not_supported` warning.

Both sanitisers live post-resolution, not in config validation, because `h264_auto`/`hevc_auto` resolve their backend per-host at flow start — a value legal for the x264 one host picks is illegal for the NVENC another picks, and neither is knowable at config load. Validation stays permissive over the union of vocabularies. QSV/VAAPI tunes are deliberately not rejected at validation (they expose no `tune`; libavcodec ignores unknown dict entries) — the sanitiser just drops them to keep the dictionary honest.

**Testing:** `no_backend_ever_receives_a_tune_it_rejects` sweeps every backend × every tune in both vocabularies; the two vocabularies are asserted disjoint. Verified on hardware (GTX 1080 Ti, driver 580, FFmpeg n7.1.3): an `h264_nvenc` flow with **no `tune` key at all** now opens and streams at 10.1 Mbps; before, the identical config died at `avcodec_open2` with -22. `preset: "ultrafast"` on `h264_nvenc` likewise now opens (one warning) and streams.
