### PR TITLE
fix(build): declare the encoder timebase fields — main does not compile

### DIFF
--- a/src/engine/video_encode_util.rs
+++ b/src/engine/video_encode_util.rs
@@ -244,6 +244,13 @@ pub fn build_encoder_config(
         height,
         fps_num,
         fps_den,
+        // `0 / 0` derives the timebase as `1 / fps` — the historical contract
+        // every caller here relies on (they feed a frame counter as pts).
+        // Ingest paths whose pts are natively 90 kHz call `set_pts_90k()` to
+        // override; feeding 90 kHz ticks into a `1 / fps` timebase segfaults
+        // libx264's VBV. See `VideoEncoderConfig::time_base_num`.
+        time_base_num: 0,
+        time_base_den: 0,
         bitrate_kbps,
         max_bitrate_kbps: cfg.max_bitrate_kbps.unwrap_or(0),
         gop_size,


### PR DESCRIPTION
`bilbycast-edge` main has not compiled against `bilbycast-ffmpeg-video-rs` main since #3 merged there:

```
src/engine/video_encode_util.rs:241:5: error[E0063]: missing fields
  `time_base_den` and `time_base_num` in initializer of `VideoEncoderConfig`
```

`build_encoder_config` initialises that struct with an exhaustive literal and no `..Default::default()`, so adding two required fields upstream broke the build outright.

`0 / 0` is the upstream default and derives the timebase as `1 / fps` — the historical contract every caller here relies on — so this is behaviour-preserving.

Went unnoticed because no CI job compiles the edge on pull requests (`codeql.yml` is `build-mode: none`; `nightly-release.yml` only builds on tags). A local checkout also masks it whenever the ffmpeg-video-rs sibling sits on a branch cut before the field landed. #57 carries the same two lines; this lands them standalone so the tree builds without waiting on an SDI review.

**Verified:** `cargo check` against `bilbycast-ffmpeg-video-rs` origin/main goes from E0063 to clean.

Merge this first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E3SLzD3RfV6oNhiedtamFJ