### PR TITLE
packaging: allow NVIDIA CUDA device classes in the systemd unit

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -419,6 +419,33 @@ separate package** for the encoder itself.
 The Nouveau open-source driver does **not** support NVENC — only the
 proprietary driver exposes the NVENC engine.
 
+**Under the packaged systemd service, group membership alone is not
+enough.** `bilbycast-edge.service` sandboxes the process with
+`DeviceAllow=` cgroup rules, which restrict device access by kernel
+device class regardless of file permissions or group membership — even
+root inside the cgroup can't open a device class that isn't explicitly
+allowed. NVIDIA's CUDA compute stack (used by NVENC/NVDEC) registers
+under `nvidia` / `nvidiactl` / `nvidia-uvm`, entirely separate char-major
+classes from `drm` (`/proc/devices`), so a unit that only allows
+`char-drm` blocks NVENC/NVDEC while DRM/VAAPI display output keeps
+working fine — a confusing split where the GPU is clearly detected
+(`nvidia-smi` works, the display path works) but transcoding fails with
+`CUDA_ERROR_NO_DEVICE`. The unit installed by `install-edge.sh` already
+includes the required `char-nvidia` / `char-nvidiactl` / `char-nvidia-uvm`
+`DeviceAllow` entries alongside `char-drm`. If you're running a custom
+unit or one built before this was added, add:
+
+```ini
+DeviceAllow=char-nvidia rwm
+DeviceAllow=char-nvidiactl rwm
+DeviceAllow=char-nvidia-uvm rwm
+```
+
+then `sudo systemctl daemon-reload && sudo systemctl restart bilbycast-edge`.
+These are harmless no-ops on hosts without an NVIDIA driver loaded — the
+device classes are never registered, so there's nothing for the rule to
+match.
+
 ```bash
 # Ubuntu 22.04 / 24.04 — install the recommended driver branch
 sudo ubuntu-drivers autoinstall

--- a/packaging/bilbycast-edge.service
+++ b/packaging/bilbycast-edge.service
@@ -38,6 +38,17 @@ NoNewPrivileges=true
 # a hardcoded /dev/dri/cardN list breaks on the third GPU.
 DeviceAllow=char-drm rwm
 DeviceAllow=char-alsa rwm
+# NVIDIA's CUDA compute stack (NVENC/NVDEC) registers under separate
+# char-major device classes from `drm` — `nvidia`/`nvidiactl`/`nvidia-uvm`
+# per /proc/devices, not covered by char-drm. Without these, `cuInit()`
+# fails with CUDA_ERROR_NO_DEVICE even though /dev/nvidia* exists with
+# correct permissions and the driver is fully functional — DRM/VAAPI
+# display output keeps working (it only needs char-drm) while NVENC/NVDEC
+# silently never do. Harmless no-op on hosts with no NVIDIA driver loaded
+# (the device classes are never registered, so there's nothing to match).
+DeviceAllow=char-nvidia rwm
+DeviceAllow=char-nvidiactl rwm
+DeviceAllow=char-nvidia-uvm rwm
 SupplementaryGroups=video render audio
 # CAP_NET_ADMIN — required by kernel ≥ 6.x for setsockopt(SO_TXTIME)
 # with CLOCK_TAI. Without it, wire-emit falls back to clock_nanosleep.


### PR DESCRIPTION
Fixes #63.

## Problem

`packaging/bilbycast-edge.service` hardens the unit with `DeviceAllow=char-drm rwm` + `char-alsa rwm`. Any `DeviceAllow=` implicitly sets `DevicePolicy=closed` for the cgroup, so only explicitly listed device classes are reachable. NVIDIA's CUDA compute stack (used by NVENC/NVDEC) registers under **separate** char-major device classes from `drm`:

```
195 nvidia
195 nvidia-modeset
195 nvidiactl
510 nvidia-uvm
```

None of those are `drm`, so they're silently blocked — even though `/dev/nvidia*` exists with correct permissions and the driver is fully loaded. `cuInit()` fails cleanly with `CUDA_ERROR_NO_DEVICE`, `hardware_probe.rs` correctly reports no HW encoders (it's not a probe bug — the device really is unreachable from inside the sandbox), and the manager UI faithfully shows "No HW encoders" on hosts where NVENC should absolutely work. DRM/VAAPI display output keeps working throughout, since it only needs `char-drm` — which is what made this easy to miss.

## Fix

Add the three missing `DeviceAllow` entries, matching the existing class-based pattern (survives hotplug renumbering, works for any number of GPUs):

```ini
DeviceAllow=char-nvidia rwm
DeviceAllow=char-nvidiactl rwm
DeviceAllow=char-nvidia-uvm rwm
```

Also documents the requirement in `docs/installation.md`'s "Running on an NVIDIA host (NVENC)" section — the existing guidance ("add the user to the `video` group") is necessary but not sufficient under the packaged unit, since cgroup device rules apply regardless of group membership.

## Verification

Confirmed on hardware (`bilby-z440`, GTX 1080 Ti, driver 580.159.03):

**Before:**
```
[h264_nvenc @ ...] dl_fn->cuda_dl->cuInit(0) failed -> CUDA_ERROR_NO_DEVICE: no CUDA-capable device is detected
INFO bilbycast_edge: hardware probe: ...; hw_encoders any=false; ...
```

**After** (same host, only the 3 `DeviceAllow` lines added + restart):
```
INFO bilbycast_edge::engine::hardware_probe: nvenc encoder 1080p session capacity probed: 8
INFO bilbycast_edge::engine::hardware_probe: nvenc encoder 4K session capacity probed: 8
INFO bilbycast_edge: hardware probe: ...; hw_encoders any=true; ...
```

And confirmed reaching the manager (`GET /api/v1/nodes/{id}`): `h264_nvenc: true`, `hevc_nvenc: true`, `video-encoder-nvenc` / `video-decoder-nvdec` capabilities advertised, correct session limits.

No code changes — packaging + docs only, so no test suite impact. Harmless no-op on hosts with no NVIDIA driver loaded, same as the existing `char-drm`/`char-alsa` entries (the device classes are never registered on such a host, so there's nothing for the rule to match).

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>