### PR TITLE
packaging: allow the Rockchip MPP device class in the systemd unit

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -393,6 +393,24 @@ At runtime the edge probes `avcodec_open2("h264_rkmpp")` and only advertises
 `/dev/mpp_service` exists but the probe fails, the startup log names the
 likely cause (user not in `video`, or `librockchip_mpp < 1.3.8`).
 
+**Under the packaged systemd service, group membership alone is not
+enough** — same caveat as the NVIDIA/NVENC section above. `bilbycast-edge.service`
+sandboxes the process with `DeviceAllow=` cgroup rules, which restrict device
+access by kernel device class regardless of file permissions or group
+membership. Rockchip's MPP device registers under its own char-major class —
+`241 mpp_service` in `/proc/devices` — entirely separate from `drm`, so a
+unit that doesn't explicitly allow it blocks RKMPP even with `/dev/mpp_service`
+world-writable and the user correctly in `video`: `avcodec_open2` fails with
+`Failed to initialize MPP context (-1)`. The unit installed by `install-edge.sh`
+already includes `DeviceAllow=char-mpp_service rwm`. If you're running a custom
+unit or one built before this was added, add:
+
+```ini
+DeviceAllow=char-mpp_service rwm
+```
+
+then `sudo systemctl daemon-reload && sudo systemctl restart bilbycast-edge`.
+
 **Headless hardening — mask sleep targets on BSP desktop images.** The
 FriendlyELEC / vendor Ubuntu BSP images ship a full GNOME desktop whose
 default power policy suspends the machine after inactivity. On a headless

--- a/packaging/bilbycast-edge.service
+++ b/packaging/bilbycast-edge.service
@@ -50,6 +50,15 @@ DeviceAllow=char-alsa rwm
 DeviceAllow=char-nvidia rwm
 DeviceAllow=char-nvidia-frontend rwm
 DeviceAllow=char-nvidia-uvm rwm
+# Rockchip MPP (RKMPP hardware encode, RK3568/RK3588). Same reasoning as
+# the NVIDIA block above — /dev/mpp_service registers under its own
+# char-major class (241, 'mpp_service' in /proc/devices), not 'drm', so
+# it's silently blocked without this even though the device node itself
+# is world-writable. Confirmed on a NanoPi R6S (RK3588S): without this
+# line, avcodec_open2 fails ("Failed to initialize MPP context (-1)")
+# despite librockchip-mpp being installed and the VPU working outside
+# the edge process (rockchip-mpp-demos' mpi_enc_test).
+DeviceAllow=char-mpp_service rwm
 SupplementaryGroups=video render audio
 # CAP_NET_ADMIN — required by kernel ≥ 6.x for setsockopt(SO_TXTIME)
 # with CLOCK_TAI. Without it, wire-emit falls back to clock_nanosleep.


### PR DESCRIPTION
Fixes #65.

## Problem

Same bug class as the earlier NVENC fix (`0705621`). `packaging/bilbycast-edge.service`'s `DeviceAllow=` entries implicitly set `DevicePolicy=closed` for the cgroup — only explicitly listed device classes are reachable. `/dev/mpp_service` (Rockchip's MPP hardware-encode device) registers under its own char-major class:

```
$ cat /proc/devices | grep -i mpp
241 mpp_service
```

That's entirely separate from `drm`, so RKMPP was silently blocked even with `/dev/mpp_service` world-writable and the `bilbycast` user correctly in the `video` group. Symptom:

```
[h264_rkmpp @ ...] Failed to initialize MPP context (-1).
WARN bilbycast_edge::engine::hardware_probe: rkmpp probe failed for h264_rkmpp: avcodec_open2 failed (code -542398533). The MPP kernel node /dev/mpp_service is present — check that librockchip_mpp is >= 1.3.8 and the VPU driver is loaded.
```

Found this rolling RKMPP out to real hardware (`bilby-pir6s`, NanoPi R6S / RK3588S) as the hardware-in-the-loop verification #48 asked for — using the new `aarch64-linux-rockchip` v0.98.1 build.

## Fix

```ini
DeviceAllow=char-mpp_service rwm
```

Placed alongside the existing `char-drm`/`char-alsa`/NVIDIA lines, matching the established pattern.

## Verification

Confirmed on hardware (NanoPi R6S, RK3588S):

**Before:**
```
WARN ... rkmpp probe failed for h264_rkmpp: avcodec_open2 failed ...
INFO bilbycast_edge: hardware probe: ...; hw_encoders any=false; ...
```

**After** (same host, only the 1 `DeviceAllow` line added + restart):
```
INFO bilbycast_edge::engine::hardware_probe: rkmpp encoder 1080p session capacity probed: 32
INFO bilbycast_edge::engine::hardware_probe: rkmpp encoder 4K session capacity probed: 8
INFO bilbycast_edge: hardware probe: ...; hw_encoders any=true; ...
```

MPP logs show real rate-control negotiation (`h264e_api_v2`/`h265e_api` setting bitrate/fps/GOP), not just a probe-open success — this is genuine hardware encode working, closing the #48 hardware-in-the-loop gap.

Also extends `docs/installation.md`'s RKMPP section with the same device-permission caveat the NVENC section already documents — group membership alone isn't sufficient under the packaged unit.

No code changes — packaging + docs only. Harmless no-op on non-Rockchip hosts (the device class is never registered there).

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>