### PR TITLE
fix(display): fix HDMI frame-grabbing (audio-stall pacing) + VAAPI driver install + decode-backend logging (#70)

### DIFF
--- a/packaging/install-edge.sh
+++ b/packaging/install-edge.sh
@@ -255,9 +255,17 @@ fi
 #                                 dynamic numa link would NEED libnuma.so.1
 # All have STABLE major SONAMEs (.1/.2) that do not churn across distro
 # releases, so the plain package name resolves on Ubuntu 22.04 → 26.04+.
-# Installed best-effort; the actual HW *drivers* (mesa-va-drivers /
-# intel-media-va-driver / libmfx-gen1.2 / NVIDIA driver) are an operator
-# concern — without them the runtime probe simply skips that backend.
+#
+# libva2 is only the *loader*: VAAPI does nothing until a backend DRIVER is
+# behind it. Without one, `av_hwdevice_ctx_create(VAAPI)` fails, the startup
+# probe reports no VAAPI capability, and the `display` output + transcode
+# decode path silently fall back to CPU — observed in the field as HDMI
+# frame-grabbing on an Intel node whose iHD driver was simply never installed
+# (issue #70): libva2 was present, the driver was not, and nothing said so.
+# The free VAAPI drivers are therefore installed best-effort alongside the
+# loader (all royalty-free — MIT / Mesa — so safe to pull automatically; the
+# runtime loads whichever matches the GPU and ignores the rest). Only the
+# proprietary NVIDIA driver + libmfx-gen1.2 (QSV) remain an operator concern.
 if command -v apt-get > /dev/null 2>&1; then
     echo "Installing runtime media libraries for variant '${VARIANT}'…"
     DEBIAN_FRONTEND=noninteractive apt-get update -qq || true
@@ -268,15 +276,27 @@ if command -v apt-get > /dev/null 2>&1; then
     if [[ "${VARIANT}" == "full" ]]; then
         DEBIAN_FRONTEND=noninteractive apt-get install -y -qq \
             libva2 libva-drm2 libdrm2 libnuma1 || true
+        # VAAPI backend drivers (see note above). `va-driver-all` is the VA-API
+        # driver metapackage — it pulls the Mesa gallium radeonsi driver (AMD)
+        # and the legacy i965 driver (Intel Gen9-) on every arch, and survives
+        # the Ubuntu 26.04 rename where the standalone `mesa-va-drivers` package
+        # was folded into `mesa-libgallium`. Modern Intel (Gen8+/Broadwell+
+        # through Alder Lake and newer) needs the iHD driver, which va-driver-all
+        # does NOT guarantee — its Intel alternative is satisfied by the older
+        # i965, which has no Gen12 support — so `intel-media-va-driver` is pulled
+        # explicitly on x86_64.
+        DEBIAN_FRONTEND=noninteractive apt-get install -y -qq va-driver-all || true
         if [[ "${ARCH}" == "x86_64-linux" ]]; then
             DEBIAN_FRONTEND=noninteractive apt-get install -y -qq libvpl2 || true
+            DEBIAN_FRONTEND=noninteractive apt-get install -y -qq intel-media-va-driver || true
         fi
     fi
 else
     echo "WARNING: apt-get unavailable — ensure libasound2 (all variants) and,"
     echo "         for the full variant, libva2 / libva-drm2 / libdrm2 / libnuma1"
-    echo "         / libvpl2 (x86_64) are installed, or the binary may fail to"
-    echo "         start. See docs.bilbycast.com/edge/installation/."
+    echo "         / libvpl2 (x86_64) plus a VAAPI driver (va-driver-all, and"
+    echo "         intel-media-va-driver on modern Intel) are installed, or HW decode"
+    echo "         silently falls back to CPU. See docs.bilbycast.com/edge/installation/."
 fi
 
 ensure_cosign() {

--- a/src/display/clock.rs
+++ b/src/display/clock.rs
@@ -38,11 +38,32 @@ use std::time::Instant;
 const INTERP_CAP_US: u64 = 120_000;
 
 /// Beyond this many µs since the last `set_position`, treat the clock as
-/// **unavailable** (reads return `None`). At this point the audio task is
-/// genuinely wedged (codec death, ALSA device hang, channel closed without
-/// teardown) and the display loop should fall back to free-running video on
-/// wall-clock rather than pacing to a frozen clock forever.
-const STALE_US: u64 = 2_000_000;
+/// **unavailable** (reads return `None`) so the display loop stops pacing
+/// video to a frozen audio clock and free-runs on wall-clock instead (the
+/// fallback re-seeds from the current frame's PTS, so the switch is
+/// seamless).
+///
+/// This only ever fires when *video frames keep arriving but audio does
+/// not* — a live source that stalls gaps both essences together, so there
+/// are no video frames to pace and this threshold is irrelevant. The one
+/// case it governs is a media player looping a playlist where some clips
+/// carry audio and some don't (or a `.ts` clip with a gappy audio PID):
+/// on the silent clip the audio task stops publishing positions, the clock
+/// freezes at the previous clip's last playout PTS, and every arriving
+/// video frame measures progressively "ahead" of it — so the pacing loop
+/// sleeps up to `catchup_cap_ms` per frame waiting for sound that never
+/// comes, and the panel judders/freezes until this cutoff trips.
+///
+/// It was 2 s, which meant up to ~2 s of frozen/limping video at *every*
+/// audio→silence transition — visible as heavy frame-grabbing on a
+/// mixed-audio playlist. A few ALSA periods (~20–32 ms each) plus xrun
+/// recovery is the most a *live* audio task ever legitimately goes quiet,
+/// so 250 ms cleanly distinguishes "audio momentarily behind" (keep the
+/// clock, ride it out via the `INTERP_CAP_US` freeze) from "audio isn't
+/// coming" (free-run video now). Flipping to wall-clock a touch early on a
+/// rare long hiccup is harmless — video stays smooth and the measured
+/// clock re-locks the instant audio resumes.
+const STALE_US: u64 = 250_000;
 
 /// Measured audio-playout clock. Constructed empty; the audio task calls
 /// [`AudioClock::set_position`] on the first successful ALSA write and
@@ -171,14 +192,33 @@ mod tests {
     fn interpolation_is_capped_on_stall() {
         let c = AudioClock::new();
         c.set_position(Instant::now(), 1_000_000);
-        // Simulate a long stall well past the cap.
-        thread::sleep(Duration::from_millis(200));
+        // A stall past the interpolation cap but still inside the staleness
+        // window (150 ms: > INTERP_CAP_US 120 ms, < STALE_US 250 ms).
+        thread::sleep(Duration::from_millis(150));
         let smoothed = c.current_pts_90k_smoothed().unwrap();
         let delta = smoothed.wrapping_sub(1_000_000);
-        // Capped at INTERP_CAP_US (120 ms) = 10_800 PTS; never the full 200 ms.
+        // Capped at INTERP_CAP_US (120 ms) = 10_800 PTS; never the full 150 ms.
         assert!(
             delta <= 10_800 + 900,
             "interpolation should cap near 120 ms, got {delta} PTS",
+        );
+    }
+
+    #[test]
+    fn goes_stale_quickly_so_display_can_free_run_on_silence() {
+        // A clip with no audio stops advancing the clock. Past STALE_US the
+        // reader must report `None` promptly (not hold a frozen value for
+        // seconds) so the display loop reverts to wall-clock video pacing
+        // instead of juddering against dead audio — the mixed-audio-playlist
+        // frame-grabbing fix.
+        let c = AudioClock::new();
+        c.set_position(Instant::now(), 1_000_000);
+        assert!(c.current_pts_90k_smoothed().is_some());
+        // Just past the 250 ms cutoff (plus margin for a slow sleep).
+        thread::sleep(Duration::from_millis(320));
+        assert!(
+            c.current_pts_90k_smoothed().is_none(),
+            "clock should read stale (None) within ~250 ms of audio going silent",
         );
     }
 

--- a/src/engine/output_display.rs
+++ b/src/engine/output_display.rs
@@ -670,7 +670,6 @@ async fn run_display_output(
         crate::config::models::HwDecodePreference::Nvdec => DecoderBackend::Nvdec,
         crate::config::models::HwDecodePreference::Qsv => DecoderBackend::Qsv,
         crate::config::models::HwDecodePreference::Vaapi => DecoderBackend::Vaapi,
-        crate::config::models::HwDecodePreference::Rkmpp => DecoderBackend::Rkmpp,
     };
     let demux_frame_gen = Arc::clone(&frame_gen);
     // Snapshot the panel's HDR signalling capability now (kms is moved
@@ -753,7 +752,6 @@ async fn run_display_output(
         (crate::engine::hardware_probe::ResolvedDisplayDecoder::Vaapi, _) => {
             "vaapi-zerocopy"
         }
-        (crate::engine::hardware_probe::ResolvedDisplayDecoder::Rkmpp, _) => "rkmpp",
     };
     let display_frame_gen = Arc::clone(&frame_gen);
     let display_force_cpu_blit = Arc::clone(&force_cpu_blit_for_bars);
@@ -1815,7 +1813,6 @@ fn backend_name(backend: DecoderBackend) -> &'static str {
         DecoderBackend::Nvdec => "nvdec",
         DecoderBackend::Qsv => "qsv",
         DecoderBackend::Vaapi => "vaapi",
-        DecoderBackend::Rkmpp => "rkmpp",
     }
 }
 

--- a/src/engine/output_display.rs
+++ b/src/engine/output_display.rs
@@ -281,6 +281,46 @@ async fn run_display_output(
         };
     let backend = resolved.as_backend();
 
+    // Surface the resolved video-decode backend at startup so an operator can
+    // tell hardware from software decode at a glance. A silent CPU fallback on
+    // a host that *should* be doing VAAPI — GPU present but the libva backend
+    // driver missing, or this binary built without `video-decoder-vaapi` — was
+    // previously invisible: the display output just ran hot on CPU and grabbed
+    // frames under load with nothing in the logs to say why (issue #70). An
+    // explicit `hw_decode` that can't be honoured already emits the
+    // `display_hw_decode_unavailable_falling_back` Warning above; here we cover
+    // the `Auto → CPU` case (which is otherwise silent) and the success case.
+    if matches!(
+        resolved,
+        crate::engine::hardware_probe::ResolvedDisplayDecoder::Cpu
+    ) && matches!(pref, crate::config::models::HwDecodePreference::Auto)
+    {
+        let any_hw_decoder_compiled = cfg!(feature = "video-decoder-vaapi")
+            || cfg!(feature = "video-decoder-nvdec")
+            || cfg!(feature = "video-decoder-qsv")
+            || cfg!(feature = "video-decoder-rkmpp");
+        let hint = if !any_hw_decoder_compiled {
+            "no hardware video-decoder compiled into this build — use a `full` \
+             release variant (or build with e.g. `video-decoder-vaapi`)"
+        } else {
+            "no usable hardware decoder detected at startup — on Intel/AMD \
+             install a VAAPI driver (`va-driver-all`, plus `intel-media-va-driver` \
+             on modern Intel); on NVIDIA the proprietary driver"
+        };
+        tracing::warn!(
+            output_id = %config.id,
+            "display '{}' video decode backend: cpu (auto) — {hint}",
+            config.id,
+        );
+    } else {
+        tracing::info!(
+            output_id = %config.id,
+            "display '{}' video decode backend: {}",
+            config.id,
+            backend_name(backend),
+        );
+    }
+
     // 1. Open KMS at the connector's preferred mode. The actual mode the
     //    panel runs at is decided by `config.scaling_mode`:
     //    - `MatchSource` (default): the display loop re-modesets to the
@@ -630,6 +670,7 @@ async fn run_display_output(
         crate::config::models::HwDecodePreference::Nvdec => DecoderBackend::Nvdec,
         crate::config::models::HwDecodePreference::Qsv => DecoderBackend::Qsv,
         crate::config::models::HwDecodePreference::Vaapi => DecoderBackend::Vaapi,
+        crate::config::models::HwDecodePreference::Rkmpp => DecoderBackend::Rkmpp,
     };
     let demux_frame_gen = Arc::clone(&frame_gen);
     // Snapshot the panel's HDR signalling capability now (kms is moved
@@ -712,6 +753,7 @@ async fn run_display_output(
         (crate::engine::hardware_probe::ResolvedDisplayDecoder::Vaapi, _) => {
             "vaapi-zerocopy"
         }
+        (crate::engine::hardware_probe::ResolvedDisplayDecoder::Rkmpp, _) => "rkmpp",
     };
     let display_frame_gen = Arc::clone(&frame_gen);
     let display_force_cpu_blit = Arc::clone(&force_cpu_blit_for_bars);
@@ -1773,6 +1815,7 @@ fn backend_name(backend: DecoderBackend) -> &'static str {
         DecoderBackend::Nvdec => "nvdec",
         DecoderBackend::Qsv => "qsv",
         DecoderBackend::Vaapi => "vaapi",
+        DecoderBackend::Rkmpp => "rkmpp",
     }
 }
 


### PR DESCRIPTION
## Summary

Three fixes to the local-display (HDMI) output, all found investigating HDMI **frame-grabbing** on a media-player→display flow. They're independent but related, so they ride together:

### 1. Free-run video quickly when a clip has no audio — *the frame-grabbing fix* (`src/display/clock.rs`)

The display output is audio-master: it paces video to the measured audio-playout clock. When the audio task stopped publishing positions, `AudioClock` returned a **frozen** value for up to `STALE_US` = **2 s** before reporting `None` and letting the loop fall back to wall-clock video pacing.

That 2 s is invisible for a live source (a stall gaps audio+video together). But a media player looping a playlist where some clips have audio and some don't — or a `.ts` clip with a gappy audio PID — hits it at **every** audio→silence transition: the clock freezes at the previous clip's last PTS, each new video frame measures progressively "ahead" of it, and the loop sleeps up to `catchup_cap_ms` per frame waiting for sound that never comes → the panel judders/freezes for ~2 s per transition.

Fix: drop `STALE_US` to **250 ms**. A live audio task never legitimately goes quiet longer than a few ALSA periods + xrun recovery, so 250 ms cleanly separates "audio momentarily behind" from "audio isn't coming" → free-run video (re-seeding the wall-clock anchor from the current frame's PTS, a seamless switch), and re-lock the instant audio resumes.

### 2. Install a VAAPI backend driver (`packaging/install-edge.sh`)

The installer pulled `libva2` (the loader) but not a backend **driver**, deferring it to the operator. Without a driver, `av_hwdevice_ctx_create(VAAPI)` fails, the probe reports no VAAPI, and the display + transcode decode paths silently run on CPU. Now pulls the free drivers on the full variant: `va-driver-all` (AMD Mesa + legacy Intel; survives the Ubuntu 26.04 `mesa-va-drivers`→`mesa-libgallium` rename) plus `intel-media-va-driver` on x86_64 for the modern Intel iHD.

### 3. Log the resolved decode backend (`src/engine/output_display.rs`)

The display output logged nothing about its decode backend, so a silent `Auto → CPU` fallback (missing driver, or a build without `video-decoder-vaapi`) was invisible. Now logs it at startup — INFO on success (`video decode backend: vaapi`), WARN with an actionable driver/feature hint on the silent `Auto → CPU` case.

## Verification (hardware — Intel Alder Lake node, HDMI, media player looping mixed clips)

- VAAPI decode engaged: `decoder_kind=vaapi-zerocopy`, `decoder_demotions=0`, GPU video engine doing the work; manager Resources card shows `VAAPI h264+hevc — 1 session`; new log reads `display 'HDMI' video decode backend: vaapi`.
- **Frame-grabbing gone**: a fully-silent clip and a `.ts` clip whose audio gapped both previously froze the panel for ~2 s each. With the clock fix, every clip holds its native frame rate (GRAVITY 50 fps, Big Buck Bunny 24 fps, Car 60 fps) with no stalls — confirmed on the panel by the operator and via per-clip displayed-fps sampling.

Refs #70.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
