### PR TITLE
fix: two silent-failure hardening fixes (NVIDIA version mismatch, hot-add port conflicts)

### DIFF
--- a/src/api/inputs.rs
+++ b/src/api/inputs.rs
@@ -6,7 +6,7 @@ use axum::extract::{Path, State};
 
 use crate::config::models::InputDefinition;
 use crate::config::persistence::save_config_split_async;
-use crate::config::validation::validate_input_definition;
+use crate::config::validation::{validate_input_definition, validate_port_conflicts_with_input};
 
 use super::auth::RequireAdmin;
 use super::errors::ApiError;
@@ -60,6 +60,8 @@ pub async fn create_input(
         .map_err(|e| ApiError::BadRequest(format!("Validation failed: {e}")))?;
 
     let mut config = state.config.write().await;
+    validate_port_conflicts_with_input(&config, &input)
+        .map_err(|e| ApiError::BadRequest(format!("Port conflict: {e}")))?;
 
     // Check for duplicate ID
     if config.inputs.iter().any(|i| i.id == input.id) {
@@ -101,6 +103,8 @@ pub async fn update_input(
         .map_err(|e| ApiError::BadRequest(format!("Validation failed: {e}")))?;
 
     let mut config = state.config.write().await;
+    validate_port_conflicts_with_input(&config, &input)
+        .map_err(|e| ApiError::BadRequest(format!("Port conflict: {e}")))?;
 
     let idx = config
         .inputs

--- a/src/api/outputs.rs
+++ b/src/api/outputs.rs
@@ -6,7 +6,7 @@ use axum::extract::{Path, State};
 
 use crate::config::models::OutputConfig;
 use crate::config::persistence::save_config_split_async;
-use crate::config::validation::validate_output;
+use crate::config::validation::{validate_output, validate_port_conflicts_with_output};
 
 use super::auth::RequireAdmin;
 use super::errors::ApiError;
@@ -60,6 +60,8 @@ pub async fn create_output(
         .map_err(|e| ApiError::BadRequest(format!("Validation failed: {e}")))?;
 
     let mut config = state.config.write().await;
+    validate_port_conflicts_with_output(&config, &output)
+        .map_err(|e| ApiError::BadRequest(format!("Port conflict: {e}")))?;
 
     // Check for duplicate ID
     if config.outputs.iter().any(|o| o.id() == output.id()) {
@@ -106,6 +108,8 @@ pub async fn update_output(
         .map_err(|e| ApiError::BadRequest(format!("Validation failed: {e}")))?;
 
     let mut config = state.config.write().await;
+    validate_port_conflicts_with_output(&config, &output)
+        .map_err(|e| ApiError::BadRequest(format!("Port conflict: {e}")))?;
 
     let idx = config
         .outputs

--- a/src/api/tunnels.rs
+++ b/src/api/tunnels.rs
@@ -44,6 +44,18 @@ pub async fn create_tunnel(
     if let Err(e) = crate::config::validation::validate_tunnel(&config) {
         return (StatusCode::BAD_REQUEST, Json(serde_json::json!({ "error": e.to_string() }))).into_response();
     }
+    // Cross-entity check against the prospective config, before the runtime
+    // is touched (see validate_port_conflicts_with_tunnel).
+    if let Err(e) = crate::config::validation::validate_port_conflicts_with_tunnel(
+        &*state.config.read().await,
+        &config,
+    ) {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(serde_json::json!({ "error": format!("Port conflict: {e}") })),
+        )
+            .into_response();
+    }
     let persisted = config.clone();
     match state.tunnel_manager.create_tunnel(config).await {
         Ok(()) => {

--- a/src/config/validation.rs
+++ b/src/config/validation.rs
@@ -7601,6 +7601,53 @@ fn reject_srt_caller_self_connect(
     Ok(())
 }
 
+/// Cross-entity port-conflict check for a **prospective** config: `config`
+/// with `input` substituted (replacing any entry of the same id, otherwise
+/// appended).
+///
+/// [`validate_config`] runs the same check at load, but the hot-add paths
+/// (`create_input` / `update_input` / `add_input` over the manager WS, and
+/// the local REST mirrors) validate only the entity in isolation. A live
+/// edit could therefore introduce a clash the *running* process tolerates —
+/// the new listener simply fails to bind, or the entity is inert — which
+/// then becomes a hard startup failure on the next restart. The node runs
+/// happily for days and refuses to boot at the worst possible moment.
+/// Hardware-confirmed on bilby-z440: a manager-side edit put an SRT output
+/// on the same UDP port as an egress tunnel, and the box crash-looped ten
+/// times into the systemd restart limit after an unrelated reboot.
+pub fn validate_port_conflicts_with_input(
+    config: &AppConfig,
+    input: &InputDefinition,
+) -> Result<()> {
+    let mut probe = config.clone();
+    probe.inputs.retain(|i| i.id != input.id);
+    probe.inputs.push(input.clone());
+    validate_port_conflicts(&probe)
+}
+
+/// Output twin of [`validate_port_conflicts_with_input`].
+pub fn validate_port_conflicts_with_output(
+    config: &AppConfig,
+    output: &OutputConfig,
+) -> Result<()> {
+    let mut probe = config.clone();
+    let id = output.id().to_string();
+    probe.outputs.retain(|o| o.id() != id);
+    probe.outputs.push(output.clone());
+    validate_port_conflicts(&probe)
+}
+
+/// Tunnel twin of [`validate_port_conflicts_with_input`].
+pub fn validate_port_conflicts_with_tunnel(
+    config: &AppConfig,
+    tunnel: &crate::tunnel::TunnelConfig,
+) -> Result<()> {
+    let mut probe = config.clone();
+    probe.tunnels.retain(|t| t.id != tunnel.id);
+    probe.tunnels.push(tunnel.clone());
+    validate_port_conflicts(&probe)
+}
+
 /// Validates that no two components in the config try to bind the same local
 /// port.  Called at the end of [`validate_config`] after individual component
 /// validation has already passed.
@@ -11450,6 +11497,123 @@ mod tests {
         let err = validate_config(&config).unwrap_err().to_string();
         assert!(err.contains("[in-1]"), "should include input id: {err}");
         assert!(err.contains("[out-1]"), "should include output id: {err}");
+    }
+
+    // ── Hot-add cross-entity port-conflict tests ──
+    //
+    // `validate_config` catches these at load, but the hot-add paths only
+    // validated the entity in isolation, so a live edit could seed a config
+    // that the running process tolerated and the next restart rejected.
+
+    /// Reproduces the bilby-z440 incident: a manager-side edit put an SRT
+    /// output on the same UDP port as a live egress tunnel. Entity-level
+    /// validation passes — that is exactly why the clash got in.
+    #[test]
+    fn hot_add_output_rejects_port_clash_with_tunnel() {
+        use crate::tunnel::config::{TunnelDirection, TunnelProtocol};
+        let config = make_tunnel_config(vec![make_test_tunnel(
+            "Z440 to BITE",
+            "0.0.0.0:9001",
+            TunnelProtocol::Udp,
+            TunnelDirection::Egress,
+        )]);
+        let output = srt_caller_output("SRT-OUT", Some("127.0.0.1:9001"), "10.0.0.5:7000");
+
+        // The gap: the entity on its own is perfectly valid.
+        assert!(validate_output(&output).is_ok());
+
+        let err = validate_port_conflicts_with_output(&config, &output)
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("Port conflict"), "got: {err}");
+        assert!(err.contains("9001"), "got: {err}");
+    }
+
+    #[test]
+    fn hot_add_output_accepts_free_port() {
+        use crate::tunnel::config::{TunnelDirection, TunnelProtocol};
+        let config = make_tunnel_config(vec![make_test_tunnel(
+            "Z440 to BITE",
+            "0.0.0.0:9001",
+            TunnelProtocol::Udp,
+            TunnelDirection::Egress,
+        )]);
+        let output = srt_caller_output("SRT-OUT", Some("127.0.0.1:9002"), "10.0.0.5:7000");
+        assert!(validate_port_conflicts_with_output(&config, &output).is_ok());
+    }
+
+    /// An in-place edit must not conflict with the entity's own previous
+    /// definition — substitution replaces by id rather than appending.
+    /// Without this, every `update_output` on a bound port would be refused.
+    #[test]
+    fn hot_update_output_does_not_conflict_with_itself() {
+        let mut config = make_tunnel_config(vec![]);
+        let output = srt_caller_output("SRT-OUT", Some("127.0.0.1:9001"), "10.0.0.5:7000");
+        config.outputs.push(output.clone());
+        assert!(validate_port_conflicts_with_output(&config, &output).is_ok());
+    }
+
+    #[test]
+    fn hot_add_input_rejects_port_clash_with_tunnel() {
+        use crate::tunnel::config::{TunnelDirection, TunnelProtocol};
+        let config = make_tunnel_config(vec![make_test_tunnel(
+            "egress",
+            "0.0.0.0:9001",
+            TunnelProtocol::Udp,
+            TunnelDirection::Egress,
+        )]);
+        let input = srt_caller_input("SRT-IN", Some("127.0.0.1:9001"), "10.0.0.5:7000");
+        assert!(validate_input_definition(&input).is_ok());
+        let err = validate_port_conflicts_with_input(&config, &input)
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("Port conflict"), "got: {err}");
+    }
+
+    /// The mirror image of the z440 incident — the tunnel arriving second.
+    #[test]
+    fn hot_add_tunnel_rejects_port_clash_with_output() {
+        use crate::tunnel::config::{TunnelDirection, TunnelProtocol};
+        let mut config = make_tunnel_config(vec![]);
+        config
+            .outputs
+            .push(srt_caller_output("SRT-OUT", Some("127.0.0.1:9001"), "10.0.0.5:7000"));
+        let tunnel = make_test_tunnel(
+            "Z440 to BITE",
+            "0.0.0.0:9001",
+            TunnelProtocol::Udp,
+            TunnelDirection::Egress,
+        );
+        // NB: no `validate_tunnel` assertion here — `make_test_tunnel` is a
+        // relay-mode fixture with no encryption key, which entity validation
+        // rejects on its own grounds. The input/output twins above make the
+        // "entity-level validation passes" point on fixtures that do.
+        let err = validate_port_conflicts_with_tunnel(&config, &tunnel)
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("Port conflict"), "got: {err}");
+        assert!(err.contains("9001"), "got: {err}");
+    }
+
+    #[test]
+    fn hot_update_tunnel_does_not_conflict_with_itself() {
+        use crate::tunnel::config::{TunnelDirection, TunnelProtocol};
+        let tunnel = make_test_tunnel(
+            "egress",
+            "0.0.0.0:9001",
+            TunnelProtocol::Udp,
+            TunnelDirection::Egress,
+        );
+        let config = make_tunnel_config(vec![tunnel.clone()]);
+        assert!(validate_port_conflicts_with_tunnel(&config, &tunnel).is_ok());
+    }
+
+    #[test]
+    fn hot_update_input_does_not_conflict_with_itself() {
+        let mut config = make_tunnel_config(vec![]);
+        let input = srt_caller_input("SRT-IN", Some("127.0.0.1:9001"), "10.0.0.5:7000");
+        config.inputs.push(input.clone());
+        assert!(validate_port_conflicts_with_input(&config, &input).is_ok());
     }
 
     // ── SRT caller `local_addr` (source-bind) tests — Issue 12 ──

--- a/src/engine/hardware_probe.rs
+++ b/src/engine/hardware_probe.rs
@@ -1198,19 +1198,114 @@ fn nvenc_unavailable_diagnostic(hw: &HwCodecCapability) -> Option<HwEncoderDiagn
     let detail = match failure {
         EncoderFailure::Busy => {
             "NVENC session slots exhausted — another process is holding all encode sessions"
+                .to_string()
         }
-        _ if node_present => {
-            "NVIDIA driver present but device unopenable — check the service \
-             DeviceAllow / cgroup sandbox (see installation.md)"
-        }
+        // A stale kernel module is by far the most common cause of a
+        // present-but-unopenable NVIDIA stack, and it is silent: the box
+        // keeps running, the encode just degrades to CPU. Name it exactly
+        // rather than sending the operator to the DeviceAllow runbook.
+        _ if node_present => match nvidia_driver_version_mismatch() {
+            Some((kernel, userspace)) => format!(
+                "NVIDIA kernel module {kernel} does not match userspace libraries \
+                 {userspace} — the driver packages were upgraded without reloading the \
+                 module (typically unattended-upgrades). Reboot, or reload nvidia.ko, to \
+                 restore NVENC. Consider holding the nvidia-*/libnvidia-* packages on \
+                 GPU nodes so an unattended upgrade cannot silently drop encoding to CPU."
+            ),
+            None => "NVIDIA driver present but device unopenable — check the service \
+                     DeviceAllow / cgroup sandbox (see installation.md)"
+                .to_string(),
+        },
         _ => "no /dev/nvidia* device nodes — the NVIDIA driver is not installed or nvidia.ko \
-              is not loaded",
+              is not loaded"
+            .to_string(),
     };
     Some(HwEncoderDiagnostic {
         family: "nvenc".into(),
         status: status.into(),
-        detail: detail.into(),
+        detail,
     })
+}
+
+/// `true` for a dotted numeric version token such as `580.159.03`.
+fn is_dotted_version(token: &str) -> bool {
+    token.contains('.')
+        && token.chars().all(|c| c.is_ascii_digit() || c == '.')
+        && token.starts_with(|c: char| c.is_ascii_digit())
+}
+
+/// Pull the driver version out of `/proc/driver/nvidia/version` contents.
+///
+/// The line reads like
+/// `NVRM version: NVIDIA UNIX x86_64 Kernel Module  580.159.03  Fri Apr 24 …`.
+/// The surrounding prose varies by driver branch and architecture, so this
+/// takes the first dotted-numeric token rather than anchoring on position.
+fn parse_nvrm_version(contents: &str) -> Option<String> {
+    contents
+        .lines()
+        .find(|l| l.starts_with("NVRM version:"))?
+        .split_whitespace()
+        .find(|tok| is_dotted_version(tok))
+        .map(str::to_string)
+}
+
+/// Pull the driver version out of a versioned NVIDIA library filename —
+/// `libnvidia-encode.so.580.173.02` → `580.173.02`.
+fn parse_nvidia_lib_version(file_name: &str, stem: &str) -> Option<String> {
+    let suffix = file_name.strip_prefix(stem)?.strip_prefix(".so.")?;
+    is_dotted_version(suffix).then(|| suffix.to_string())
+}
+
+/// Directories searched for the versioned NVIDIA userspace libraries.
+/// Covers Debian/Ubuntu multiarch and the RHEL/Fedora `lib64` layout.
+const NVIDIA_LIB_DIRS: &[&str] = &[
+    "/usr/lib/x86_64-linux-gnu",
+    "/usr/lib/aarch64-linux-gnu",
+    "/usr/lib64",
+    "/usr/lib",
+];
+
+/// Library stems whose soname carries the userspace driver version.
+/// `libcuda` is the fallback: NVENC hosts always have it, whereas
+/// `libnvidia-encode` is absent on decode-only installs.
+const NVIDIA_VERSIONED_LIBS: &[&str] = &["libnvidia-encode", "libcuda"];
+
+/// Userspace NVIDIA driver version, read from the versioned library soname.
+/// Deliberately avoids NVML — that is behind an optional Cargo feature, and
+/// on a mismatched host `nvmlInit` is exactly what fails.
+fn nvidia_userspace_version() -> Option<String> {
+    for dir in NVIDIA_LIB_DIRS {
+        let Ok(entries) = std::fs::read_dir(dir) else {
+            continue;
+        };
+        for entry in entries.flatten() {
+            let name = entry.file_name().to_string_lossy().into_owned();
+            for stem in NVIDIA_VERSIONED_LIBS {
+                if let Some(v) = parse_nvidia_lib_version(&name, stem) {
+                    return Some(v);
+                }
+            }
+        }
+    }
+    None
+}
+
+/// Loaded kernel-module version, or `None` when `nvidia.ko` is not loaded.
+fn nvidia_kernel_module_version() -> Option<String> {
+    parse_nvrm_version(&std::fs::read_to_string("/proc/driver/nvidia/version").ok()?)
+}
+
+/// `Some((kernel, userspace))` when both versions resolve **and** disagree.
+///
+/// Upgrading the NVIDIA packages without rebooting leaves the running
+/// `nvidia.ko` older than the userspace libraries; `cuInit` then fails with
+/// `CUDA_ERROR_COMPAT_NOT_SUPPORTED_ON_DEVICE` and every HW encode silently
+/// falls back to CPU. Hardware-confirmed on bilby-z440, where it went
+/// unnoticed for three days because the only symptom was elevated CPU.
+fn nvidia_driver_version_mismatch() -> Option<(String, String)> {
+    let kernel = nvidia_kernel_module_version()?;
+    let userspace = nvidia_userspace_version()?;
+    (kernel != userspace).then_some((kernel, userspace))
 }
 
 /// QSV diagnostic. `None` unless QSV is compiled in yet unavailable. The
@@ -3612,6 +3707,66 @@ mod tests {
             let advertised = render_node_matches(nodes, QSV_DRM_DRIVERS) && opened;
             assert_eq!(advertised, expected, "{case}");
         }
+    }
+
+    /// Real `/proc/driver/nvidia/version` contents from bilby-z440 during
+    /// the 2026-07-25 mismatch incident.
+    #[test]
+    fn parses_nvrm_version_from_real_proc_contents() {
+        let contents = "NVRM version: NVIDIA UNIX x86_64 Kernel Module  580.159.03  \
+                        Fri Apr 24 06:16:47 UTC 2026\nGCC version:\n";
+        assert_eq!(parse_nvrm_version(contents).as_deref(), Some("580.159.03"));
+    }
+
+    #[test]
+    fn parses_nvrm_version_on_other_architectures() {
+        // aarch64 line carries a different arch token in the same position.
+        let contents = "NVRM version: NVIDIA UNIX aarch64 Kernel Module  535.104.05  \
+                        Sat Aug 19 01:15:15 UTC 2023\n";
+        assert_eq!(parse_nvrm_version(contents).as_deref(), Some("535.104.05"));
+    }
+
+    #[test]
+    fn nvrm_version_absent_when_module_not_loaded() {
+        assert_eq!(parse_nvrm_version(""), None);
+        assert_eq!(parse_nvrm_version("something else entirely\n"), None);
+    }
+
+    #[test]
+    fn parses_versioned_library_soname() {
+        assert_eq!(
+            parse_nvidia_lib_version("libnvidia-encode.so.580.173.02", "libnvidia-encode")
+                .as_deref(),
+            Some("580.173.02")
+        );
+        assert_eq!(
+            parse_nvidia_lib_version("libcuda.so.580.173.02", "libcuda").as_deref(),
+            Some("580.173.02")
+        );
+        // The unversioned symlinks must not be mistaken for a version.
+        assert_eq!(
+            parse_nvidia_lib_version("libnvidia-encode.so", "libnvidia-encode"),
+            None
+        );
+        assert_eq!(
+            parse_nvidia_lib_version("libnvidia-encode.so.1", "libnvidia-encode"),
+            None
+        );
+        // Wrong stem must not match a same-prefixed library.
+        assert_eq!(
+            parse_nvidia_lib_version("libcudart.so.12.4.99", "libcuda"),
+            None
+        );
+    }
+
+    #[test]
+    fn dotted_version_rejects_non_versions() {
+        assert!(is_dotted_version("580.159.03"));
+        assert!(is_dotted_version("12.4"));
+        assert!(!is_dotted_version("580")); // no dot
+        assert!(!is_dotted_version("Module")); // no digits
+        assert!(!is_dotted_version("x86_64")); // not dotted-numeric
+        assert!(!is_dotted_version("")); // empty
     }
 
     /// No render nodes at all is still unambiguously `no_driver`.

--- a/src/manager/client.rs
+++ b/src/manager/client.rs
@@ -23,7 +23,11 @@ use super::events::{Event, EventSeverity, build_event_envelope, category};
 use crate::config::models::{AppConfig, FlowAssembly, FlowConfig, FlowGroupConfig, InputDefinition, OutputConfig, ResolvedFlow};
 use crate::config::persistence::save_config_split_async;
 use crate::config::secrets::SecretsConfig;
-use crate::config::validation::{validate_config, validate_flow, validate_input_definition, validate_output, validate_tunnel};
+use crate::config::validation::{
+    validate_config, validate_flow, validate_input_definition, validate_output,
+    validate_port_conflicts_with_input, validate_port_conflicts_with_output,
+    validate_port_conflicts_with_tunnel, validate_tunnel,
+};
 use crate::engine::manager::FlowManager;
 use crate::engine::resource_monitor::SystemResourceState;
 use crate::tunnel::TunnelConfig;
@@ -2378,6 +2382,11 @@ async fn execute_command(
                 serde_json::from_value(action["output"].clone())
                     .map_err(|e| format!("Invalid output config: {e}"))?;
             validate_output(&output).map_err(|e| CommandError::from_validation("Invalid output config", e))?;
+            // Cross-entity check against the prospective config, before the
+            // runtime is touched — otherwise the clash only surfaces on the
+            // next cold start (see validate_port_conflicts_with_output).
+            validate_port_conflicts_with_output(&*app_config.read().await, &output)
+                .map_err(|e| CommandError::from_validation("Port conflict", e))?;
             tracing::info!("Manager command: add output to flow '{flow_id}'");
             flow_manager
                 .add_output(flow_id, output.clone())
@@ -2427,6 +2436,10 @@ async fn execute_command(
                     .map_err(|e| format!("Invalid input config: {e}"))?;
             validate_input_definition(&input)
                 .map_err(|e| CommandError::from_validation("Invalid input config", e))?;
+            // Cross-entity check against the prospective config, before the
+            // runtime is touched (see validate_port_conflicts_with_input).
+            validate_port_conflicts_with_input(&*app_config.read().await, &input)
+                .map_err(|e| CommandError::from_validation("Port conflict", e))?;
             let input_id = input.id.clone();
             tracing::info!(
                 "Manager command: add input '{input_id}' to flow '{flow_id}' (hot-add)"
@@ -2541,6 +2554,8 @@ async fn execute_command(
             validate_input_definition(&input).map_err(|e| CommandError::from_validation("Invalid input", e))?;
             tracing::info!("Manager command: create input '{}' ({})", input.id, input.config.type_name());
             let mut cfg = app_config.write().await;
+            validate_port_conflicts_with_input(&cfg, &input)
+                .map_err(|e| CommandError::from_validation("Port conflict", e))?;
             if cfg.inputs.iter().any(|i| i.id == input.id) {
                 return Err(CommandError::new(format!("Input '{}' already exists", input.id)));
             }
@@ -2560,6 +2575,8 @@ async fn execute_command(
             validate_input_definition(&input).map_err(|e| CommandError::from_validation("Invalid input", e))?;
             tracing::info!("Manager command: update input '{input_id}'");
             let mut cfg = app_config.write().await;
+            validate_port_conflicts_with_input(&cfg, &input)
+                .map_err(|e| CommandError::from_validation("Port conflict", e))?;
             let idx = cfg.inputs.iter().position(|i| i.id == input_id)
                 .ok_or_else(|| format!("Input '{input_id}' not found"))?;
             let old = cfg.inputs[idx].clone();
@@ -2724,6 +2741,8 @@ async fn execute_command(
             validate_output(&output).map_err(|e| CommandError::from_validation("Invalid output", e))?;
             tracing::info!("Manager command: create output '{}' ({})", output.id(), output.type_name());
             let mut cfg = app_config.write().await;
+            validate_port_conflicts_with_output(&cfg, &output)
+                .map_err(|e| CommandError::from_validation("Port conflict", e))?;
             if cfg.outputs.iter().any(|o| o.id() == output.id()) {
                 return Err(CommandError::new(format!("Output '{}' already exists", output.id())));
             }
@@ -2743,6 +2762,8 @@ async fn execute_command(
             validate_output(&output).map_err(|e| CommandError::from_validation("Invalid output", e))?;
             tracing::info!("Manager command: update output '{output_id}'");
             let mut cfg = app_config.write().await;
+            validate_port_conflicts_with_output(&cfg, &output)
+                .map_err(|e| CommandError::from_validation("Port conflict", e))?;
             let idx = cfg.outputs.iter().position(|o| o.id() == output_id)
                 .ok_or_else(|| format!("Output '{output_id}' not found"))?;
             let old_output = cfg.outputs[idx].clone();
@@ -2820,6 +2841,10 @@ async fn execute_command(
                 .map_err(|e| format!("Invalid tunnel config: {e}"))?;
             tunnel.normalize_relay_addrs();
             validate_tunnel(&tunnel).map_err(|e| CommandError::from_validation("Invalid tunnel config", e))?;
+            // Cross-entity check against the prospective config, before the
+            // runtime is touched (see validate_port_conflicts_with_tunnel).
+            validate_port_conflicts_with_tunnel(&*app_config.read().await, &tunnel)
+                .map_err(|e| CommandError::from_validation("Port conflict", e))?;
             tracing::info!("Manager command: create tunnel '{}'", tunnel.id);
             tunnel_manager
                 .create_tunnel(tunnel.clone())


### PR DESCRIPTION
> **Stacked on #77.** Base is `fix/hw-probe-render-node-vendor`, not `main` — the first commit touches `hardware_probe.rs` in the same region as #77, so branching off `main` would have guaranteed a conflict. **Merge #77 first**, then this retargets to `main` cleanly. Review the two commits independently; they are unrelated and split cleanly if you'd rather take them as separate PRs.

Both fixes come out of the same bilby-z440 incident, and both are the same *class* of bug: **a failure that leaves the node running, so nobody finds out.**

---

## 1. `fix(hardware-probe)`: name the NVIDIA driver/userspace version mismatch

Upgrading the NVIDIA packages without rebooting leaves the running `nvidia.ko` older than the userspace libraries. `cuInit` then fails with `CUDA_ERROR_COMPAT_NOT_SUPPORTED_ON_DEVICE`, NVENC drops out, and every hardware encode falls back to CPU. The box keeps running — the only symptom is elevated CPU.

The diagnostic pointed operators at the DeviceAllow / cgroup runbook, which was **the wrong tree entirely**; that mechanism was working fine. On bilby-z440 this went unnoticed for **three days** after `unattended-upgrades` moved userspace 580.159.03 → 580.173.02 against a kernel module still on 580.159.03.

Now compares the loaded module version (`/proc/driver/nvidia/version`) against the userspace version in the `libnvidia-encode` / `libcuda` soname, and when they disagree, says so with the remedy:

> NVIDIA kernel module 580.159.03 does not match userspace libraries 580.173.02 — the driver packages were upgraded without reloading the module (typically unattended-upgrades). Reboot, or reload nvidia.ko, to restore NVENC. Consider holding the nvidia-*/libnvidia-* packages on GPU nodes…

Deliberately avoids NVML: it's behind an optional Cargo feature, and on a mismatched host `nvmlInit` is precisely what fails.

## 2. `fix(config)`: run cross-entity port-conflict checks on the hot-add paths

`validate_config` runs `validate_port_conflicts` at load, but every hot-add path validated only the entity **in isolation** — `create`/`update` input, output and tunnel over the manager WS, plus the local REST mirrors. A live edit could seed a config the running process tolerates (the new listener simply fails to bind, or the entity is inert) that becomes a **hard startup failure on the next restart**.

The node runs happily for days and refuses to boot at the worst possible moment. On bilby-z440 a manager-side edit put an SRT output on the same UDP port as a live egress tunnel; it ran for hours, then crash-looped ten times into the systemd restart limit after an unrelated reboot — with no obvious connection to the edit that caused it.

Adds `validate_port_conflicts_with_{input,output,tunnel}`, which check the **prospective** config (current config with the candidate substituted *by id*, so an in-place edit never conflicts with its own previous definition), wired at all ten sites **before the runtime is touched**.

Delete paths are deliberately untouched — removing an entity cannot introduce a conflict.

---

## Verification

**1758 tests pass**, 12 of them new.

The one failure, `testbed_adaptive_contribution_configs_validate`, is **pre-existing and environmental** — it reads `../testbed/configs/…` from a sibling repo that isn't checked out on the build host. It exists on the base commit and this diff doesn't touch it.

Hardware-verified on bilby-z440 for fix 1 — the case unit tests *can't* cover, since a wrong `NVIDIA_LIB_DIRS` or stem match would still pass every unit test while the feature silently never fires:

```
kernel module : Some("580.173.02")
userspace lib : Some("580.173.02")   <- directory scan finds real libraries
mismatch      : None                 <- healthy host raises no false alarm
```

The mismatch case itself is covered by a unit test over the **real** `/proc/driver/nvidia/version` string captured during the incident.

Fix 2 is covered by unit tests reproducing the incident in both directions (output added against an existing tunnel, and tunnel added against an existing output), plus the self-substitution cases that would otherwise make every `update_*` on a bound port fail. It is **not** hardware-verified: this branch is `main`-based, and z440 currently runs a build carrying unmerged media-player work, so deploying it there would have regressed that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)